### PR TITLE
Use of refresh token

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ class PixivApp {
     }
 
     if (refreshToken !== "") {
-	  console.log(refreshToken);
       data.grant_type = 'refresh_token'
       data.refresh_token = refreshToken
     }

--- a/index.js
+++ b/index.js
@@ -51,13 +51,13 @@ class PixivApp {
     }
 
     if (loginInfo.refresh !== "") {
-      data.grant_type === 'refresh_token';
-      data.refresh_token === this.refresh;      
+      data.grant_type = 'refresh_token'
+      data.refresh_token = this.refresh      
     }
     else {
-      data.grant_type === 'password';
-      data.username === this.username;
-      data.password === this.password;
+      data.grant_type = 'password'
+      data.username = this.username
+      data.password = this.password
     }
     return axios
       .post('https://oauth.secure.pixiv.net/auth/token', stringify(data))

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { stringify } = require('querystring')
 const axios = require('axios')
 const camelcaseKeys = require('camelcase-keys')
 const decamelizeKeys = require('decamelize-keys')
+var loginInfo = {username: "", password: "", refresh: ""}
 
 const baseURL = 'https://app-api.pixiv.net/'
 const instance = axios.create({
@@ -43,20 +44,27 @@ class PixivApp {
       )
     }
 
-    const data = {
+    var data = {
       client_id: 'bYGKuGVw91e0NMfPGp44euvGt59s',
       client_secret: 'HP3RmkgAmEGro0gn1x9ioawQE8WMfvLXDz3ZqxpK',
-      get_secure_url: 1,
-      grant_type: 'password',
-      username: this.username,
-      password: this.password
+      get_secure_url: 1
     }
 
+    if (loginInfo.refresh !== "") {
+      data.grant_type === 'refresh_token';
+      data.refresh_token === this.refresh;      
+    }
+    else {
+      data.grant_type === 'password';
+      data.username === this.username;
+      data.password === this.password;
+    }
     return axios
       .post('https://oauth.secure.pixiv.net/auth/token', stringify(data))
       .then(res => {
         const { response } = res.data
         this.auth = response
+        loginInfo.refresh = res.data.response.refresh_token
         instance.defaults.headers.common.Authorization = `Bearer ${
           response.access_token
         }`

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const { stringify } = require('querystring')
 const axios = require('axios')
 const camelcaseKeys = require('camelcase-keys')
 const decamelizeKeys = require('decamelize-keys')
-var refreshToken = "";
 
 const baseURL = 'https://app-api.pixiv.net/'
 const instance = axios.create({
@@ -22,6 +21,7 @@ class PixivApp {
   constructor(username, password, opts) {
     this.username = username
     this.password = password
+    this.refreshToken = "";
     opts = opts || { camelcaseKeys: true }
     if (opts.camelcaseKeys) {
       this.camelcaseKeys = true
@@ -50,21 +50,21 @@ class PixivApp {
       get_secure_url: 1
     }
 
-    if (refreshToken === "") {
+    if (this.refreshToken === "") {
       data.grant_type = 'password'
       data.username = this.username
       data.password = this.password
     }
     else {
       data.grant_type = 'refresh_token'
-      data.refresh_token = refreshToken
+      data.refresh_token = this.refreshToken
     }
     return axios
       .post('https://oauth.secure.pixiv.net/auth/token', stringify(data))
       .then(res => {
         const { response } = res.data
         this.auth = response
-        refreshToken = res.data.response.refresh_token
+        this.refreshToken = res.data.response.refresh_token
         instance.defaults.headers.common.Authorization = `Bearer ${
           response.access_token
         }`

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class PixivApp {
 
     if (loginInfo.refresh !== "") {
       data.grant_type = 'refresh_token'
-      data.refresh_token = this.refresh      
+      data.refresh_token = loginInfo.refresh      
     }
     else {
       data.grant_type = 'password'

--- a/index.js
+++ b/index.js
@@ -50,14 +50,14 @@ class PixivApp {
       get_secure_url: 1
     }
 
-    if (refreshToken !== "") {
-      data.grant_type = 'refresh_token'
-      data.refresh_token = refreshToken
-    }
-    else {
+    if (refreshToken === "") {
       data.grant_type = 'password'
       data.username = this.username
       data.password = this.password
+    }
+    else {
+      data.grant_type = 'refresh_token'
+      data.refresh_token = refreshToken
     }
     return axios
       .post('https://oauth.secure.pixiv.net/auth/token', stringify(data))

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { stringify } = require('querystring')
 const axios = require('axios')
 const camelcaseKeys = require('camelcase-keys')
 const decamelizeKeys = require('decamelize-keys')
-var loginInfo = {username: "", password: "", refresh: ""}
+var refreshToken = "";
 
 const baseURL = 'https://app-api.pixiv.net/'
 const instance = axios.create({
@@ -45,14 +45,15 @@ class PixivApp {
     }
 
     var data = {
-      client_id: 'bYGKuGVw91e0NMfPGp44euvGt59s',
-      client_secret: 'HP3RmkgAmEGro0gn1x9ioawQE8WMfvLXDz3ZqxpK',
+      client_id: 'KzEZED7aC0vird8jWyHM38mXjNTY',
+      client_secret: 'W9JZoJe00qPvJsiyCGT3CCtC6ZUtdpKpzMbNlUGP',
       get_secure_url: 1
     }
 
-    if (loginInfo.refresh !== "") {
+    if (refreshToken !== "") {
+	  console.log(refreshToken);
       data.grant_type = 'refresh_token'
-      data.refresh_token = loginInfo.refresh      
+      data.refresh_token = refreshToken
     }
     else {
       data.grant_type = 'password'
@@ -64,7 +65,7 @@ class PixivApp {
       .then(res => {
         const { response } = res.data
         this.auth = response
-        loginInfo.refresh = res.data.response.refresh_token
+        refreshToken = res.data.response.refresh_token
         instance.defaults.headers.common.Authorization = `Bearer ${
           response.access_token
         }`


### PR DESCRIPTION
**READ BEFORE MERGE**

Due to unknown reasons, I found out that the original `client_id` and `client_secret` you have cannot use refresh token (All generated refresh tokens are invalid). Thus, I have to use another client id and secret from another library.

I have tested this by calling `.login()` twice, 1 minute apart (And only one email occurred).

You might also want to push the fix [here](https://github.com/akameco/PixivDeck/issues/140), I s'pose.