### PR TITLE
Fixed type of illustDetail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -404,11 +404,15 @@ Gets your friends on Mypixiv.
 
 Gets a user list.
 
-#### `illustDetail(id: ID, params?: PixivParams): Promise<PixivIllust>`
+#### `illustDetail(id: ID, params?: PixivParams): Promise<PixivIllustDetail>`
 
 Returns detailed info for a pixiv illust.
 
 ```ts
+export interface PixivIllustDetail {
+  illust: PixivIllust
+}
+
 export interface PixivIllust {
   id: number
   title: string

--- a/src/PixivTypes.ts
+++ b/src/PixivTypes.ts
@@ -146,6 +146,10 @@ export interface PixivUserDetail {
   }
 }
 
+export interface PixivIllustDetail {
+  illust: PixivIllust
+}
+
 export interface PixivIllustSearch {
   illusts: PixivIllust[]
   nextUrl: string | null

--- a/src/Pixiv_Types.ts
+++ b/src/Pixiv_Types.ts
@@ -96,6 +96,10 @@ export interface Pixiv_User_Detail {
   }
 }
 
+export interface Pixiv_Illust_Detail {
+  illust: Pixiv_Illust
+}
+
 export interface Pixiv_Illust_Search {
   illusts: Pixiv_Illust[]
   next_url: string | null

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   Pixiv_User_Detail,
   Pixiv_Illust_Search,
   Pixiv_User_Search,
-  Pixiv_Illust,
+  Pixiv_Illust_Detail,
   Pixiv_Comment_Search,
   Pixiv_Trend_Tags,
   Pixiv_Novel_Search,
@@ -29,7 +29,7 @@ import {
   PixivBookmarkSearch,
   PixivUserDetail,
   PixivUserSearch,
-  PixivIllust,
+  PixivIllustDetail,
   PixivCommentSearch,
   PixivNovelSearch,
   PixivAutoComplete,
@@ -332,7 +332,9 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
   illustDetail(
     id: number,
     params?: PixivParams
-  ): Promise<CamelcaseKeys extends true ? PixivIllust : Pixiv_Illust> {
+  ): Promise<
+    CamelcaseKeys extends true ? PixivIllustDetail : Pixiv_Illust_Detail
+  > {
     if (!id) {
       return Promise.reject(new Error('illustId required'))
     }


### PR DESCRIPTION
**What**:
Due to the structure of the REST response for `illustDetail` its currently impossible to use the illustDetail method as the actual `PixivIllust` type is only available using the `illust` property of the REST response.

**Why**:
Fixing the unusable `illustDetail` method.

**How**:
Porting the changes from #22 to be a standalone change as suggested by @Tenpi, so adding a new type having the `illust` property and changing the return type of `illustDetail` itself.

**Checklist**:
- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A
