### PR TITLE
fix: import specific functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'querystring'
-import * as crypto from 'crypto'
-import url from 'url'
+import { createHash as cryptoCreateHash } from 'crypto'
+import { parse as urlParse } from 'url'
 import axios, { AxiosRequestConfig } from 'axios'
 import decamelizeKeys from 'decamelize-keys'
 import camelcaseKeys from 'camelcase-keys'
@@ -119,8 +119,7 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
 
     const headers = {
       'X-Client-Time': local_time,
-      'X-Client-Hash': crypto
-        .createHash('md5')
+      'X-Client-Hash': cryptoCreateHash('md5')
         .update(Buffer.from(`${local_time}${HASH_SECRET}`, 'utf8'))
         .digest('hex')
     }
@@ -179,7 +178,7 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
   nextQuery(): undefined | string {
     // This always returns undefined
     // @ts-ignore
-    return url.parse(this.nextUrl!, true).params
+    return urlParse(this.nextUrl!, true).params
   }
 
   makeIterable(resp: any): AsyncIterable<any> {


### PR DESCRIPTION
**What**:
Some parts of "crypto" package are depricated and because package is fully imported they appears in "pixiv-app-api" too.

For more information see #27 

<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->

**Why**:
Fixing import of functions from "crypto" package

<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->

**How**:
- import only `createHash` function from "crypto" package
- also import only `parse` from "url" package


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

Closes #27 
