### PR TITLE
Add a method to modify the internal token of Axios

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
     const { response } = axiosResponse.data
     this.auth = response
     this.refreshToken = axiosResponse.data.response.refresh_token
-    instance.defaults.headers.common.Authorization = `Bearer ${response.access_token}`
+    this.authToken = response.access_token
     return this.camelcaseKeys
       ? camelcaseKeys(response, { deep: true })
       : response
@@ -166,6 +166,11 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
           deep: true,
         }) as unknown) as authInfoType)
       : (this.auth as authInfoType)
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  set authToken(accessToken: string) {
+    instance.defaults.headers.common.Authorization = `Bearer ${accessToken}`
   }
 
   hasNext(): boolean {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->

**What**:
Add a method to modify the internal token of Axios
<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->

**Why**:
I use refresh_token to generate access_token, but cannot modify the internal token
<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->

**How**:
added a set method called `authToken`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
