### PR TITLE
Add x_restrict/xRestrict to Pixiv_Illust/PixivIllust types

### DIFF
--- a/src/PixivTypes.ts
+++ b/src/PixivTypes.ts
@@ -203,6 +203,7 @@ export interface PixivIllust {
   }
   caption: string
   restrict: number
+  xRestrict: number
   user: PixivUser
   tags: PixivTag[]
   tools: string[]

--- a/src/Pixiv_Types.ts
+++ b/src/Pixiv_Types.ts
@@ -152,6 +152,7 @@ export interface Pixiv_Illust {
   }
   caption: string
   restrict: number
+  x_restrict: number
   user: Pixiv_User
   tags: Pixiv_Tag[]
   tools: string[]


### PR DESCRIPTION
**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
The Pixiv api returns an illust object that includes `x_restrict`, but the types don't reflect that.

**Why**:
<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
When using TypeScript it complains that `xRestrict` is not a property of the `PixivIllust` object, even though it is.

**How**:
<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
I added the missing properties.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [ ] Tests - N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
