### PR TITLE
now uses v2 api for autocompletion (./v2/search/autocomplete).

### DIFF
--- a/src/PixivTypes.ts
+++ b/src/PixivTypes.ts
@@ -318,7 +318,7 @@ export interface PixivTrendTags {
 }
 
 export interface PixivAutoComplete {
-  searchAutoCompleteKeywords: string[]
+  tags: PixivTag[]
 }
 
 export interface PixivBookmarkDetail {

--- a/src/Pixiv_Types.ts
+++ b/src/Pixiv_Types.ts
@@ -267,7 +267,7 @@ export interface Pixiv_Trend_Tags {
 }
 
 export interface Pixiv_Auto_Complete {
-  search_auto_complete_keywords: string[]
+  tags: Pixiv_Tag[]
 }
 
 export interface Pixiv_Bookmark_Detail {

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,10 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
   set authToken(accessToken: string) {
     instance.defaults.headers.common.Authorization = `Bearer ${accessToken}`
   }
+  // eslint-disable-next-line class-methods-use-this
+  set language(language: string) {
+    instance.defaults.headers.common['Accept-Language'] = language
+  }
 
   hasNext(): boolean {
     return Boolean(this.nextUrl)
@@ -525,7 +529,7 @@ export default class PixivApp<CamelcaseKeys extends boolean = true> {
     if (!word) {
       return Promise.reject(new Error('word required'))
     }
-    return this.fetch('/v1/search/autocomplete', { params: { word } })
+    return this.fetch('/v2/search/autocomplete', { params: { word } })
   }
 
   illustBookmarkDetail(


### PR DESCRIPTION
now uses v2 api for autocompletion (./v2/search/autocomplete). Tags now have a translation if you change the Accept-Language header (example "en-us")

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->

Updated the method "searchAutoComplete()". It now uses v2 of the pixiv api. V2 returns the tags with translations.

**Why**:

searchAutoComplete() was more or less unuseable for english users.

**How**:

changed url from ./v1/search/autocomplete to ./v2/search/autocomplete. changed PixivAutoComplete and Pixiv_Auto_Complete to match the api. Added language setter in PixivApi class.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments. -->
